### PR TITLE
fixing call zbar_version function

### DIFF
--- a/barcode.go
+++ b/barcode.go
@@ -37,10 +37,10 @@ import "C"
 
 // Version returns the major and minor version numbers of the
 // underlying zbar library.
-func Version() (major, minor uint) {
-	var raw_major, raw_minor C.uint
-	C.zbar_version(&raw_major, &raw_minor)
-	return uint(raw_major), uint(raw_minor)
+func Version() (major, minor, patch uint) {
+	var raw_major, raw_minor, raw_patch C.uint
+	C.zbar_version(&raw_major, &raw_minor, &raw_patch)
+	return uint(raw_major), uint(raw_minor), uint(raw_patch)
 }
 
 // SetVerbosity sets the library debug level.  Higher values spew more


### PR DESCRIPTION
`go version go1.15.3 darwin/amd64`

```
# github.com/bieber/barcode
../../go/pkg/mod/github.com/bieber/barcode@v0.0.0-20200408232142-32f856f5ac58/barcode.go:42:16: not enough arguments in call to _Cfunc_zbar_version
	have (*_Ctype_uint, *_Ctype_uint)
	want (*_Ctype_uint, *_Ctype_uint, *_Ctype_uint)
```
