### PR TITLE
Fix reference loop causing memory leak

### DIFF
--- a/image.go
+++ b/image.go
@@ -84,7 +84,7 @@ func NewImage(src image.Image) *Image {
 		func(i *Image) {
 			// The image data was allocated by the Go runtime, we
 			// don't want zbar trying to free it
-			C.zbar_image_set_data(newImage.zbarImage, nil, 0, nil)
+			C.zbar_image_set_data(i.zbarImage, nil, 0, nil)
 			C.zbar_image_destroy(i.zbarImage)
 		},
 	)


### PR DESCRIPTION
This fixes a quite substantial memory leak, leaking the entire grayscale image for every created image.

By taking a reference to newImage in the closure passed to SetFinalizer a reference loop is created via the finalizer, causing it to never be freed.

Fix this by using the correct reference passed to the closure by SetFinalizer.